### PR TITLE
Preserve Data in the browser

### DIFF
--- a/Menuicon.js
+++ b/Menuicon.js
@@ -1,7 +1,6 @@
-const menuIcon = document.querySelector('.nav-icons');
-const mainNavigation = document.querySelector('.main-nav');
+const menuIcon = document.querySelector(".nav-icons");
+const mainNavigation = document.querySelector(".main-nav");
 
-menuIcon.addEventListener('click', () => {
-  mainNavigation.classList.toggle('nav-open');
-  document.body.classList.toggle('hidden');
+menuIcon.addEventListener("click", () => {
+  mainNavigation.classList.toggle("nav-open");
 });

--- a/Menuicon.js
+++ b/Menuicon.js
@@ -1,6 +1,6 @@
-const menuIcon = document.querySelector(".nav-icons");
-const mainNavigation = document.querySelector(".main-nav");
+const menuIcon = document.querySelector('.nav-icons');
+const mainNavigation = document.querySelector('.main-nav');
 
-menuIcon.addEventListener("click", () => {
-  mainNavigation.classList.toggle("nav-open");
+menuIcon.addEventListener('click', () => {
+  mainNavigation.classList.toggle('nav-open');
 });

--- a/datastorage.js
+++ b/datastorage.js
@@ -1,8 +1,8 @@
-const myDetails = document.getElementById("myform");
-const myname = document.getElementById("full-name");
-const email = document.getElementById("email");
-const message = document.getElementById("message");
-const getLocalStorage = localStorage.getItem("userProvidedInfo");
+const myDetails = document.getElementById('myform');
+const myname = document.getElementById('full-name');
+const email = document.getElementById('email');
+const message = document.getElementById('message');
+const getLocalStorage = localStorage.getItem('userProvidedInfo');
 
 // Load to each contact form fields if there is pre-saved local storage data.
 
@@ -13,13 +13,13 @@ if (getLocalStorage) {
   message.value = dataSave.message;
 }
 
-document.querySelectorAll("input, textarea").forEach((input) => {
-  input.addEventListener("input", (event) => {
+document.querySelectorAll('input, textarea').forEach((input) => {
+  input.addEventListener('input', (event) => {
     event.preventDefault();
     // Calling input values
-    const nameData = document.querySelector("#full-name").value;
-    const emailData = document.querySelector("#email").value;
-    const msgData = document.querySelector("#message").value;
+    const nameData = document.querySelector('#full-name').value;
+    const emailData = document.querySelector('#email').value;
+    const msgData = document.querySelector('#message').value;
 
     // Store values in object;
     const infoProvided = {
@@ -28,11 +28,11 @@ document.querySelectorAll("input, textarea").forEach((input) => {
       message: msgData,
     };
 
-    localStorage.setItem("userProvidedInfo", JSON.stringify(infoProvided));
+    localStorage.setItem('userProvidedInfo', JSON.stringify(infoProvided));
   });
 });
 
 // make the form staying to the current load, for visualization or testing purpose
-myDetails.addEventListener("submit", (e) => {
+myDetails.addEventListener('submit', (e) => {
   e.preventDefault();
 });

--- a/datastorage.js
+++ b/datastorage.js
@@ -1,0 +1,38 @@
+const myDetails = document.getElementById("myform");
+const myname = document.getElementById("full-name");
+const email = document.getElementById("email");
+const message = document.getElementById("message");
+const getLocalStorage = localStorage.getItem("userProvidedInfo");
+
+// Load to each contact form fields if there is pre-saved local storage data.
+
+if (getLocalStorage) {
+  const dataSave = JSON.parse(getLocalStorage);
+  myname.value = dataSave.name;
+  email.value = dataSave.email;
+  message.value = dataSave.message;
+}
+
+document.querySelectorAll("input, textarea").forEach((input) => {
+  input.addEventListener("input", (event) => {
+    event.preventDefault();
+    // Calling input values
+    const nameData = document.querySelector("#full-name").value;
+    const emailData = document.querySelector("#email").value;
+    const msgData = document.querySelector("#message").value;
+
+    // Store values in object;
+    const infoProvided = {
+      name: nameData,
+      email: emailData,
+      message: msgData,
+    };
+
+    localStorage.setItem("userProvidedInfo", JSON.stringify(infoProvided));
+  });
+});
+
+// make the form staying to the current load, for visualization or testing purpose
+myDetails.addEventListener("submit", (e) => {
+  e.preventDefault();
+});

--- a/index.html
+++ b/index.html
@@ -420,6 +420,7 @@
         <ul class="form-ul">
           <li class="form-li">
             <input
+              id="full-name"
               name="name"
               class="input"
               type="text"
@@ -431,6 +432,7 @@
           <li class="form-li">
             <input
               name="Email"
+              id="email"
               class="input"
               type="email"
               placeholder="my email@gmail.com"
@@ -444,6 +446,7 @@
               placeholder="write your message here..."
               maxlength="500"
               required
+              id="message"
             ></textarea>
           </li>
           <button type="submit" class="contact-btn">Get in touch</button>
@@ -453,5 +456,6 @@
     </section>
     <script defer src="Menuicon.js"></script>
     <script defer src="validation.js"></script>
+    <script defer src="datastorage.js"></script>
   </body>
 </html>


### PR DESCRIPTION
In this pull request I implemented the following interactions:
- When the user changes the content of any input field, the data is saved to the local storage.
-  When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.